### PR TITLE
:heavy_minus_sign: Remove Swashbuckle.Core dependency.

### DIFF
--- a/PackUtils/PackUtils.csproj
+++ b/PackUtils/PackUtils.csproj
@@ -24,7 +24,6 @@
     <PackageReference Include="RestSharp" Version="106.10.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.3.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.3.3" />
-    <PackageReference Include="Swashbuckle.Core" Version="5.6.0" />
     <PackageReference Include="TimeZoneConverter" Version="3.2.0" />
   </ItemGroup>
 


### PR DESCRIPTION
[fix] Removes Swashbuckle.Core dependency, that's not total compatible with netstandard2.0

![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

### Status

READY
### Whats?

The current version of PackUtils package has a warning about possible incompatibility because it depends on Swashbuckle.Core and that's dependency isn't necessary.

### Why?

Remove warnings.

### Definition of Done:
- [ ] Increases API documentation
- [ ] Implements integration tests
- [ ] Implements unit tests
- [ ] Is there appropriate logging included?
- [ ] Does this add new dependencies?
- [ ] Does need add new version in changelog?
- [ ] Does need update readme, contributing, etc?
- [ ] Does need change in CI server?
- [ ] Will this feature require a new piece of infrastructure be implemented?
- [ ] Does this PR require a blog post? If so, ensure marketing has signed off on content.
