### PR TITLE
[Feature] Nullable enum default converter

### DIFF
--- a/PackUtils.Test/Converters/NullableEnumDefaultValueConverterTests.cs
+++ b/PackUtils.Test/Converters/NullableEnumDefaultValueConverterTests.cs
@@ -1,0 +1,113 @@
+﻿using Newtonsoft.Json;
+
+using PackUtils.Converters;
+
+using System;
+
+using Xunit;
+
+namespace PackUtils.Test.Converters
+{
+    public class NullableEnumDefaultValueConverterTests
+    {
+        [Fact]
+        public static void NullableEnumDefaultValueTest_Should_Deserialize_InvalidValue_And_SetDefaultValue()
+        {
+            // arrange
+            var enumDefaultValue = NullableTestEnum.DefaultValue;
+            var settings = JsonUtility.LowerCaseJsonSerializerSettings;
+            settings.Converters.Clear();
+            settings.Converters.Add(new NullableEnumDefaultValueConverter(enumDefaultValue));
+
+            var json = "{\"myenumnullable\":\"invalid_value\"}";
+
+            // act
+            var objResult = JsonConvert.DeserializeObject<NullableTestEnumClass>(json, settings);
+
+            // assert
+            Assert.Equal(enumDefaultValue, objResult.MyEnumNullable.Value);
+        }
+
+        [Fact]
+        public static void NullableEnumDefaultValueTest_Should_NotDeserializeWhenEnumIsNull()
+        {
+            // arrange
+            var enumDefaultValue = NullableTestEnum.DefaultValue;
+            var settings = JsonUtility.LowerCaseJsonSerializerSettings;
+            settings.Converters.Clear();
+            settings.Converters.Add(new NullableEnumDefaultValueConverter(enumDefaultValue));
+
+            var json = "{\"not_my_myenumnullable\":\"invalid_value\"}";
+
+            // act
+            var objResult = JsonConvert.DeserializeObject<NullableTestEnumClass>(json, settings);
+
+            // assert
+            Assert.False(objResult.MyEnumNullable.HasValue);
+        }
+
+        [Fact]
+        public static void NullableEnumDefaultValueTest_Should_Deserialize_ValidValue()
+        {
+            // arrange
+            var enumDefaultValue = NullableTestEnum.DefaultValue;
+            var settings = JsonUtility.LowerCaseJsonSerializerSettings;
+            settings.Converters.Clear();
+            settings.Converters.Add(new NullableEnumDefaultValueConverter(enumDefaultValue));
+
+            var json = "{\"myenumnullable\":\"value_1\"}";
+
+            // act
+            var objResult = JsonConvert.DeserializeObject<NullableTestEnumClass>(json, settings);
+
+            // assert
+            Assert.Equal(NullableTestEnum.Value1, objResult.MyEnumNullable);
+        }
+
+        [Fact]
+        public static void NullableEnumDefaultValueTest_Should_ThrowArgumentNullException_When_DefaultValueIsNotInformed()
+        {
+            // arrange
+            var settings = JsonUtility.LowerCaseJsonSerializerSettings;
+            settings.Converters.Clear();
+
+            // act
+            Action act = () =>
+            {
+                settings.Converters.Add(new NullableEnumDefaultValueConverter());
+            };
+
+            // assert
+            Assert.Throws<ArgumentNullException>(act);
+        }
+
+        [Fact]
+        public static void NullableEnumDefaultValueTest_Should_ThrowArgumentNullException_When_NullValueIsNotInformed()
+        {
+            // arrange
+            var settings = JsonUtility.LowerCaseJsonSerializerSettings;
+            settings.Converters.Clear();
+
+            // act
+            Action act = () =>
+            {
+                settings.Converters.Add(new NullableEnumDefaultValueConverter(null));
+            };
+
+            // assert
+            Assert.Throws<ArgumentNullException>(act);
+        }
+
+        public class NullableTestEnumClass
+        {
+            public NullableTestEnum? MyEnumNullable { get; set; }
+        }
+
+        public enum NullableTestEnum
+        {
+            DefaultValue = 1,
+            Value1 = 2,
+            Value2 = 4
+        }
+    }
+}

--- a/PackUtils/Converters/NullableEnumDefaultValueConverter.cs
+++ b/PackUtils/Converters/NullableEnumDefaultValueConverter.cs
@@ -1,0 +1,130 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace PackUtils.Converters
+{
+    /// <summary>
+    ///  Nullable enum converter for newtonsoft. 
+    ///  When the sent enum value cannot be parsed, it will set a default value.
+    /// </summary>
+    public class NullableEnumDefaultValueConverter : JsonConverter
+    {
+        private readonly string _defaultValue;
+
+        public NullableEnumDefaultValueConverter()
+        {
+            throw new ArgumentNullException("enumDefaultValue", "An enum default value is required.");
+        }
+
+        public NullableEnumDefaultValueConverter(Enum enumDefaultValue)
+        {
+            if(enumDefaultValue == null)
+            {
+                throw new ArgumentNullException(nameof(enumDefaultValue), "An enum default value is required.");
+            }
+
+            _defaultValue = enumDefaultValue.ToString();
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            var type = IsNullableType(objectType)
+                            ? Nullable.GetUnderlyingType(objectType)
+                            : objectType;
+
+            return type.GetTypeInfo().IsEnum;
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var isNullable = IsNullableType(objectType);
+            var enumType = isNullable
+                ? Nullable.GetUnderlyingType(objectType)
+                : objectType;
+
+            if (!enumType.IsEnum)
+            {
+                return reader.Value;
+            }
+
+            var enumValues = Enum.GetNames(enumType);
+
+            if (reader.TokenType == JsonToken.String)
+            {
+                string enumText = reader.Value.ToString();
+
+                if (!string.IsNullOrEmpty(enumText))
+                {
+                    var match = enumValues
+                        .Where(n => string.Equals(n.Replace("_", ""), enumText.Replace("_", ""), StringComparison.OrdinalIgnoreCase))
+                        .FirstOrDefault();
+
+                    if (match != null)
+                    {
+                        return Enum.Parse(enumType, match);
+                    }
+
+                    var firstEnumValue = enumValues.FirstOrDefault();
+                    if (string.Equals(firstEnumValue.ToString(), _defaultValue))
+                    {
+                        return Enum.Parse(enumType, firstEnumValue);
+                    }
+                }
+            }
+            else if (reader.TokenType == JsonToken.Integer)
+            {
+                var enumVal = Convert.ToInt32(reader.Value);
+                var values = (int[])Enum.GetValues(enumType);
+                if (values.Contains(enumVal))
+                {
+                    return Enum.Parse(enumType, enumVal.ToString());
+                }
+            }
+
+            if (!isNullable)
+            {
+                var defaultName = enumValues
+                    .Where(n => string.Equals(n.Replace("_", ""), "Undefined", StringComparison.OrdinalIgnoreCase))
+                    .FirstOrDefault();
+
+                if (defaultName == null)
+                {
+                    defaultName = enumValues.First();
+                }
+
+                return Enum.Parse(enumType, defaultName);
+            }
+
+            return null;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var finalValue = value.ToString();
+
+            if (serializer.ContractResolver is CamelCasePropertyNamesContractResolver ||
+                serializer.ContractResolver is CustomCamelCasePropertyNamesContractResolver)
+            {
+                finalValue = finalValue.ToCamelCase();
+            }
+            else if (serializer.ContractResolver is SnakeCasePropertyNamesContractResolver)
+            {
+                finalValue = finalValue.ToSnakeCase();
+            }
+            else if (serializer.ContractResolver is LowerCasePropertyNamesContractResolver)
+            {
+                finalValue = finalValue.ToLowerCase();
+            }
+
+            writer.WriteValue(finalValue);
+        }
+
+        private bool IsNullableType(Type t)
+        {
+            return (t.GetTypeInfo().IsGenericType && t.GetGenericTypeDefinition() == typeof(Nullable<>));
+        }
+    }
+}


### PR DESCRIPTION
![Git Merge](https://camo.githubusercontent.com/803261fbe049c6c1631247f42912f216cc4c08b00f4ac25b54145b14f3cc42d8/68747470733a2f2f6d65646961312e74656e6f722e636f6d2f696d616765732f64653862653536383061383161636262313666326661346161616265663465612f74656e6f722e6769663f6974656d69643d3133323131313132)

### Status

READY

### Whats?

Add a new enum converter.

### Why?

Because we need a nullable enum that set a default value when it cannot bind the filled value. When i was implementing a feature, i needed an optional enum field but it was necessary to validate the value and return a pretty message when the sent value for the field it's not in the enum valid values. In this scenery, we cannot differenciate between a not sent field and an invalid enum value.

(Example)
Without the converter: if we fill the nullable enum field with a value that it's not equal to any of the valid enum values it will set the default nullable value(null). 

With the converter: if we fill the nullable enum field with a value that it's not equal to any of the valid enum values it will set the default value that we choose.

### How?

Implemented a new/almost the same enum converter that set a defined default value when the json deserializer cannot deserialize the field.